### PR TITLE
add-export

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ jobs:
           go test -v ./... -race -covermode=atomic
   release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        destination_os: [linux, windows, macos]
     steps:
       -
         name: Checkout
@@ -33,33 +36,13 @@ jobs:
       -
         name: Build 
         run: |
-          scripts/build.sh linux amd64
-          scripts/build.sh windows amd64
-          scripts/build.sh darwin amd64
+          scripts/build.sh ${{ matrix.destination_os }} amd64
       - 
-        name: Release Linux amd64 binaries
+        name: Release built binaries
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: build/list.linux_amd64
-          asset_name: list.linux_amd64
+          file: build/*
           tag: ${{ github.ref }}
           overwrite: true
-      - 
-        name: Release Windows amd64 binaries
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: build/list.windows_amd64
-          asset_name: list.windows_amd64
-          tag: ${{ github.ref }}
-          overwrite: true
-      - 
-        name: Release MacOS amd64 binaries
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: build/list.darwin_amd64
-          asset_name: list.darwin_amd64
-          tag: ${{ github.ref }}
-          overwrite: true
+          file_glob: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You'll need to get credentials for a [service account](https://support.google.co
 ## Setup
 ### Downloadable binaries
 
-Soon you'll be able to download already compiled binaries for Windows, MacOS, and Linux, on amd64 architecture.
+To get compiled binaries for Windows, MacOS, and Linux, on amd64 architecture, you can go to any of our [releases](https://github.com/ifosch/stationery/releases).
 
 ### From source code
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ Matching files:
  - Resignation letter (1fre23w89y892435_23498hwerfiuhp_3489uhr)
  - Contract letter (1980254tjiewv0_ewqrflikjerw9834_34298ph)
 ```
+
+### Export to HTML
+
+The command `export` exports a document matching the query to HTML. The query must match one single document:
+
+```bash
+$ export "name = 'Resume'"
+<html>...
+```

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/ifosch/docs/pkg/gdrive"
+	"github.com/ifosch/docs/pkg/stationery"
+)
+
+func main() {
+	log.SetFlags(0)
+	q := ""
+	if len(os.Args[1:]) > 0 {
+		q = strings.Join(os.Args[1:], " ")
+	}
+
+	var err error
+
+	svc, err := gdrive.GetService(os.Getenv("DRIVE_CREDENTIALS_FILE"))
+	if err != nil {
+		log.Fatalf("Failed to login: %v", err)
+	}
+
+	if len(q) == 0 {
+		log.Fatal("No query specified: this command returns only one document, please add a query returning one single document.")
+	}
+
+	r, err := stationery.GetFiles(svc, q)
+	if err != nil {
+		log.Fatalf("Invalid query: %v", err)
+	}
+
+	if len(r) > 1 {
+		log.Fatalf("Too many results: query must return only one document, not %v.", len(r))
+	}
+
+	content, err := stationery.ExportHTML(svc, r[0])
+	if err != nil {
+		log.Fatalf("Export failed: %v", err)
+	}
+
+	fmt.Println(content)
+}

--- a/pkg/gdrive/gdrive.go
+++ b/pkg/gdrive/gdrive.go
@@ -16,6 +16,24 @@ type Service struct {
 	service *drive.Service
 }
 
+// ExportFile exports the file in the first argument, returning the content in the specified MIME type, as the second argument.
+func (s *Service) ExportFile(file *drive.File, MIMEType string) (content string, err error) {
+	fe := s.service.Files.Export(file.Id, MIMEType)
+
+	resp, err := fe.Download()
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
 // GetFiles receives a query parameter and returns a list of `drive.File`s or an error.
 func (s *Service) GetFiles(q string) (files []*drive.File, err error) {
 	fl, err := s.service.Files.List().Fields("nextPageToken, files(id, name)").Q(q).Do()

--- a/pkg/stationery/stationery.go
+++ b/pkg/stationery/stationery.go
@@ -12,6 +12,12 @@ import (
 //  - `GetFiles`: based on a string parameter to specify a query, it returns a list of files metadata, or an error.
 type Service interface {
 	GetFiles(string) ([]*drive.File, error)
+	ExportFile(*drive.File, string) (string, error)
+}
+
+// ExportHTML gets an HTML version of the specified file's content.
+func ExportHTML(svc Service, file *drive.File) (content string, err error) {
+	return svc.ExportFile(file, "text/html")
 }
 
 // BuildFileList creates a printable output from a list of files.

--- a/pkg/stationery/stationery_test.go
+++ b/pkg/stationery/stationery_test.go
@@ -23,6 +23,10 @@ func (ms *MockService) GetFiles(q string) ([]*drive.File, error) {
 	return ms.responses[q], nil
 }
 
+func (ms *MockService) ExportFile(_ *drive.File, _ string) (string, error) {
+	return "", nil
+}
+
 func TestGetFiles(t *testing.T) {
 	tc := []struct {
 		input         string

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,4 +7,6 @@ mkdir -p build
 OS=${1:-$(uname -s | tr -s '[A-Z]' '[a-z')}
 ARCH=${2:-$(uname -m | sed -e 's/x86_/amd/g')}
 
-GOOS=${OS} GOARCH=${ARCH} go build -o build/list.${OS}_${ARCH} ./cmd/list
+for command in $(ls cmd); do
+    GOOS=${OS} GOARCH=${ARCH} go build -o build/$command.${OS}_${ARCH} ./cmd/list
+done


### PR DESCRIPTION
This PR includes some small fixes in the README and pipelines, and a new `export` command added.

This new code is not including new tests, as it is so simple it would
imply testing net/http or drive API.