### PR TITLE
fix-build-script

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ifosch/docs/pkg/gdrive"
-	"github.com/ifosch/docs/pkg/stationery"
+	"github.com/ifosch/stationery/pkg/gdrive"
+	"github.com/ifosch/stationery/pkg/stationery"
 )
 
 func main() {

--- a/cmd/list/main.go
+++ b/cmd/list/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ifosch/docs/pkg/gdrive"
-	"github.com/ifosch/docs/pkg/stationery"
+	"github.com/ifosch/stationery/pkg/gdrive"
+	"github.com/ifosch/stationery/pkg/stationery"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ifosch/docs
+module github.com/ifosch/stationery
 
 go 1.17
 

--- a/pkg/gdrive/gdrive.go
+++ b/pkg/gdrive/gdrive.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Service is an abstraction object for the Google Drive service.
-// It is intended to satisfy `docs.Service` interface.
+// It is intended to satisfy `stationery.Service` interface.
 type Service struct {
 	service *drive.Service
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,5 +8,5 @@ OS=${1:-$(uname -s | tr -s '[A-Z]' '[a-z')}
 ARCH=${2:-$(uname -m | sed -e 's/x86_/amd/g')}
 
 for command in $(ls cmd); do
-    GOOS=${OS} GOARCH=${ARCH} go build -o build/$command.${OS}_${ARCH} ./cmd/list
+    GOOS=${OS} GOARCH=${ARCH} go build -o build/$command.${OS}_${ARCH} ./cmd/$command
 done


### PR DESCRIPTION
Renames leftovers after renaming the project from docs to stationery.